### PR TITLE
Properly quote regex arguments

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -391,9 +391,9 @@ case "${COMMAND}" in
   --scan-history) scan_with_fn_or_die "scan_history" "$@" ;;
   --list)
     if [ ${GLOBAL} -eq 1 ]; then
-      git config --global --get-regex secrets.*
+      git config --global --get-regex 'secrets.*'
     else
-      git config --get-regex secrets.*
+      git config --get-regex 'secrets.*'
     fi
     ;;
   --install)


### PR DESCRIPTION
*Issue*

This fixes an issue with `git secrets --add-provider --global -- opscore security run git-secrets-provider -q` on my machine.

Details: https://cloudbees.slack.com/archives/CNK8SLMCG/p1762504597679809

*Description of changes:*

Quote regexp to ensure there is no globbing issue when retrieving the secrets list.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
